### PR TITLE
Fix support for swift package manager

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/DGCollectionViewLeftAlignFlowLayout.xcodeproj/project.pbxproj
+++ b/DGCollectionViewLeftAlignFlowLayout.xcodeproj/project.pbxproj
@@ -325,6 +325,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = A3169DA61DE05E8300BABAFD;
@@ -652,7 +653,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -703,7 +704,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -729,6 +730,7 @@
 				PRODUCT_NAME = DGCollectionViewLeftAlignFlowLayout;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -749,6 +751,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.digipolitan.collectionviewleftalignflowlayout;
 				PRODUCT_NAME = DGCollectionViewLeftAlignFlowLayout;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -763,6 +766,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.digipolitan.DGCollectionViewLeftAlignFlowLayoutTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -777,6 +781,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.digipolitan.DGCollectionViewLeftAlignFlowLayoutTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -798,6 +803,7 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -820,6 +826,7 @@
 				PRODUCT_NAME = DGCollectionViewLeftAlignFlowLayout;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -836,6 +843,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.digipolitan.DGCollectionViewLeftAlignFlowLayoutTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
+				SWIFT_VERSION = 5.0;
 				TVOS_DEPLOYMENT_TARGET = 10.0;
 			};
 			name = Debug;
@@ -851,6 +859,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.digipolitan.DGCollectionViewLeftAlignFlowLayoutTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
+				SWIFT_VERSION = 5.0;
 				TVOS_DEPLOYMENT_TARGET = 10.0;
 			};
 			name = Release;

--- a/DGCollectionViewLeftAlignFlowLayout.xcodeproj/project.pbxproj
+++ b/DGCollectionViewLeftAlignFlowLayout.xcodeproj/project.pbxproj
@@ -725,6 +725,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.digipolitan.collectionviewleftalignflowlayout;
 				PRODUCT_NAME = DGCollectionViewLeftAlignFlowLayout;
@@ -747,6 +748,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.digipolitan.collectionviewleftalignflowlayout;
 				PRODUCT_NAME = DGCollectionViewLeftAlignFlowLayout;
@@ -763,6 +765,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 582762VK3P;
 				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.digipolitan.DGCollectionViewLeftAlignFlowLayoutTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -778,6 +781,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 582762VK3P;
 				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.digipolitan.DGCollectionViewLeftAlignFlowLayoutTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -805,7 +809,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
 			name = Debug;
 		};
@@ -828,7 +832,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
 			name = Release;
 		};
@@ -844,7 +848,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				SWIFT_VERSION = 5.0;
-				TVOS_DEPLOYMENT_TARGET = 10.0;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
 			name = Debug;
 		};
@@ -860,7 +864,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				SWIFT_VERSION = 5.0;
-				TVOS_DEPLOYMENT_TARGET = 10.0;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
 			name = Release;
 		};

--- a/DGCollectionViewLeftAlignFlowLayout.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/DGCollectionViewLeftAlignFlowLayout.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "collection-view-left-align-flow-layout",
     platforms: [
-        .iOS(.v8)
+        .iOS(.v12)
     ],
     products: [
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -1,7 +1,24 @@
+// swift-tools-version:5.1
 import PackageDescription
 
 let package = Package(
-    name: "DGCollectionViewLeftAlignFlowLayout",
+    name: "collection-view-left-align-flow-layout",
+    platforms: [
+        .iOS(.v8)
+    ],
+    products: [
+        .library(
+            name: "collection-view-left-align-flow-layout",
+            targets: ["collection-view-left-align-flow-layout"]
+        )
+    ],
     dependencies: [
+        
+    ],
+    targets: [
+        .target(
+            name: "collection-view-left-align-flow-layout",
+            path: "Source"
+        )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -2,14 +2,14 @@
 import PackageDescription
 
 let package = Package(
-    name: "collection-view-left-align-flow-layout",
+    name: "DGCollectionViewLeftAlignFlowLayout",
     platforms: [
         .iOS(.v8)
     ],
     products: [
         .library(
-            name: "collection-view-left-align-flow-layout",
-            targets: ["collection-view-left-align-flow-layout"]
+            name: "DGCollectionViewLeftAlignFlowLayout",
+            targets: ["DGCollectionViewLeftAlignFlowLayout"]
         )
     ],
     dependencies: [
@@ -17,7 +17,7 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "collection-view-left-align-flow-layout",
+            name: "DGCollectionViewLeftAlignFlowLayout",
             path: "Sources"
         )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     targets: [
         .target(
             name: "collection-view-left-align-flow-layout",
-            path: "Source"
+            path: "Sources"
         )
     ]
 )


### PR DESCRIPTION
Hi,

this pull request change the Swift version to 5.0 and fixes the Package.swift version to use this library with the swift package manager in Xcode 11 or newer.